### PR TITLE
Bump version of bson

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "ejdb"
 
 [dependencies]
 ejdb-sys = { path = "ejdb-sys", version = "0.2" }
-bson = "0.2"
+bson = "0.3"
 bitflags = "0.7"
 quick-error = "1.1"
 libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@
 extern crate bitflags;
 #[macro_use]
 extern crate quick_error;
-extern crate bson as bson_crate;
+pub extern crate bson as bson_crate;
 extern crate itertools;
 pub extern crate ejdb_sys;
 extern crate libc;


### PR DESCRIPTION
Bump the version of bson and mark the crate as `pub` since not doing so is now a compiler error. Addresses #2.
