### PR TITLE
Fix typos in a few places in the documentation

### DIFF
--- a/src/database/indices.rs
+++ b/src/database/indices.rs
@@ -50,7 +50,7 @@ impl<'db> Collection<'db> {
 /// indices are specified for some field in collection records, so this structure is used to
 /// configure indices for one specific field.
 ///
-/// Index manipulation is done with this structure which provides builder-like interface
+/// Index manipulation is done with this structure which provides a builder-like interface
 /// to create, change properties or drop an index on one field. Since an index can't exist
 /// separately from a collection, this structure is linked via a lifetime to its corresponding
 /// collection object. An instance of this structure is obtained with `Collection::index()` method.

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -409,7 +409,7 @@ impl Default for CollectionOptions {
 /// following operations:
 ///
 /// * Executing queries.
-/// * Creating transacions.
+/// * Creating transactions.
 /// * Saving and loading objects by their identifier.
 ///
 /// Dropping and creating collections is performed through `Database` object.
@@ -467,7 +467,7 @@ impl<'db> Collection<'db> {
     /// # Failures
     ///
     /// Returns an error if the provided document can't be converted to the EJDB one or
-    /// if some error occurs which prevents the corresponding EJDB operation from successfull
+    /// if some error occurs which prevents the corresponding EJDB operation from successful
     /// completion.
     ///
     /// # Example
@@ -668,7 +668,7 @@ impl<'coll, 'db, 'out, Q, H> PreparedQuery<'coll, 'db, 'out, Q, H>
         }
     }
 
-    /// Executes the query, returning the affected number of records.
+    /// Executes the query, returning the number of affected records.
     ///
     /// This method is equivalent to `find().map(|r| r.len())` but more efficient because
     /// it does not load the actual data from the database.

--- a/src/database/query.rs
+++ b/src/database/query.rs
@@ -13,7 +13,7 @@ use utils::bson::BsonNumber;
 /// execution in EJDB. It implements `Deref<Target=bson::Document>` and `DerefMut`, therefore
 /// it is possible to work with it as a BSON document directly. It also has
 /// `into_bson()`/`as_bson()` methods and `Into<bson::Document>`/`From<bson::Document>`
-/// implemenations. If an invalid document is constructed and passed as a hints map when
+/// implementations. If an invalid document is constructed and passed as a hints map when
 /// executing a query, an error will be returned.
 ///
 /// Query hints are a part of any query operation and are passed with the actual query to
@@ -98,7 +98,7 @@ impl QueryHints {
     }
 }
 
-/// A builder for ordering hint by a specific field.
+/// A builder for the hint to order by a specific field.
 pub struct QueryHintsOrderBy(QueryHints, String);
 
 impl QueryHintsOrderBy {
@@ -215,11 +215,11 @@ impl QH {
 
 /// An EJDB query.
 ///
-/// This structure represents both a find query and an update query, because both kind of
+/// This structure represents both a find query and an update query, because both kinds of
 /// queries are executed in the same way.
 ///
 /// A query internally is a BSON document of a [certain format][queries], very similar to
-/// MongoDB queries. This structure provides convenience methods to build such document.
+/// MongoDB queries. This structure provides convenience methods to build such a document.
 /// Additionally, a query may have hints, i.e. non-data parameters affecting its behavior.
 /// These parameters are encapsulated in the `QueryHints` structure and are passed to the
 /// `Collection::query()` method separately.
@@ -532,7 +532,7 @@ enum FieldConstraintData {
 
 /// A transient builder for adding field-based query constraints.
 ///
-/// Instances of this structure are returned by `Query::field()` and `FieldConstrait::field()`
+/// Instances of this structure are returned by `Query::field()` and `FieldConstraint::field()`
 /// methods.
 pub struct FieldConstraint(Cow<'static, str>, FieldConstraintData);
 
@@ -613,7 +613,7 @@ impl FieldConstraint {
 
     /// Adds an `$exists` constraint for this field.
     ///
-    /// The field must exists if `exists` is `true`, the opposite otherwise.
+    /// The field must exist if `exists` is `true`, the opposite otherwise.
     pub fn exists(self, exists: bool) -> Query {
         self.process(bson!("$exists" => exists))
     }
@@ -637,7 +637,7 @@ impl FieldConstraint {
 
     /// Adds an `$nin` constraint for this field.
     ///
-    /// The value of this field must not be equal to all of the values yielded by `values`.
+    /// The value of this field must not be equal to any of the values yielded by `values`.
     pub fn not_contained_in<I>(self, values: I) -> Query
         where I: IntoIterator, I::Item: Into<Bson>
     {

--- a/src/database/tx.rs
+++ b/src/database/tx.rs
@@ -7,7 +7,7 @@ impl<'db> Collection<'db> {
     /// Starts a transaction, returning a guard object for it.
     ///
     /// This method can be used to start transactions over an EJDB collection. Transactions
-    /// are controlled with their guard objects, which rely on RAII pattern to abort or
+    /// are controlled with their guard objects, which rely on the RAII pattern to abort or
     /// commit transactions when appropriate.
     ///
     /// # Failures
@@ -54,8 +54,8 @@ impl<'db> Collection<'db> {
 
 /// Represents an active transaction.
 ///
-/// This structure is a transaction guard for an EJDB collection. It employs RAII pattern:
-/// a value of this structure is returned when transaction is started and when this value
+/// This structure is a transaction guard for an EJDB collection. It employs the RAII pattern:
+/// a value of this structure is returned when a transaction is started and when this value
 /// is dropped, the transaction is committed or aborted.
 ///
 /// By default when a transaction goes out of scope, it is aborted. This is done because
@@ -67,8 +67,8 @@ impl<'db> Collection<'db> {
 /// However, it is possible to change the default behavior with `set_commit()/set_abort()` methods,
 /// and it is also possible to commit or abort the transaction with `commit()`/`abort()` methods.
 /// `finish()` method is essentially equivalent to dropping the transaction guard, except that
-/// it returns a value which may contain an error (for regular drops any errors are ignord).
-/// `will_commit()`/`will_abort()` methods will `true` if their respective action will be taken
+/// it returns a value which may contain an error (for regular drops any errors are ignored).
+/// `will_commit()`/`will_abort()` methods return `true` if their respective action will be taken
 /// upon finishing.
 ///
 /// In EJDB transactions can only span one collection, therefore transactions created from a
@@ -110,11 +110,11 @@ impl<'coll, 'db> Transaction<'coll, 'db> {
     #[inline]
     pub fn will_abort(&self) -> bool { !self.commit }
 
-    /// Makes this transaction to commit when dropped.
+    /// Makes this transaction commit when dropped.
     #[inline]
     pub fn set_commit(&mut self) { self.commit = true; }
 
-    /// Makes this transaction to abort when dropped.
+    /// Makes this transaction abort when dropped.
     #[inline]
     pub fn set_abort(&mut self) { self.commit = false; }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 //! EJDB supports a pretty large subset of operations provided by MongoDB, and even has
 //! its own unique queries, like joins.
 //!
-//! Queries are perfomed with `Collection::query()` method which accepts, two arguments:
+//! Queries are performed with `Collection::query()` method which accepts, two arguments:
 //! anything which can be borrowed into a `Query` and anything which can be borrowed into
 //! a `QueryHints`. `Query` is the actual query, i.e. constraints on the data in a collection,
 //! and `QueryHints` alter the way the query is processed and returned.
@@ -134,7 +134,7 @@
 //! You can use `Collection::begin_transaction()` method which will start a transaction over
 //! this collection. Citing the official documentation:
 //!
-//! > EJDB provides atomic and durable non parallel and read-uncommited collection level
+//! > EJDB provides atomic and durable non parallel and read-uncommitted collection level
 //! > transactions, i.e., There is only one transaction for collection is active for a single
 //! > point in a time. The data written in a transaction is visible for other non transactional
 //! > readers. EJDB transaction system utilizes write ahead logging to provide consistent
@@ -145,7 +145,7 @@
 //! By default it is aborted; but you can change the default behavior with corresponding methods.
 //! Alternatively, you can explicitly commit or abort the transaction with `Transaction::commit()`
 //! or `Transaction::abort()`, respectively. Additionally, these methods return a `Result<()>`
-//! which can be used to track erros; when the transaction is closed on its drop, the result
+//! which can be used to track errors; when the transaction is closed on its drop, the result
 //! is ignored.
 //!
 //! ```no_run
@@ -155,7 +155,7 @@
 //! loop {
 //!     let tx = coll.begin_transaction().unwrap();
 //!     // execute queries and other operations
-//!     // if some error happens and the loop exists prematurely, e.g. through unwinding,
+//!     // if some error happens and the loop exits prematurely, e.g. through unwinding,
 //!     // the transaction will be aborted automatically
 //!
 //!     // try to commit the transaction and try again if there is an error


### PR DESCRIPTION
Thanks for such complete documentation in this project. Since it was so nice to read, I couldn't help but improve it here and there where there were a few typos.